### PR TITLE
perf: load game filters only when requested by user

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,5 @@
 {
-    "header": {
+    "dashboard": {
         "menuEntries": {
             "gamesKey": "Games",
             "planningKey": "Calendar",
@@ -14,25 +14,20 @@
                 "dlc": "DLCS"
             }
         },
-        "description": "Your prime destination for exciting gaming experiences !"
-    },
-    "toolbar": {
-        "settings": "Settings",
-        "modes": {
-            "title": "Mode",
-            "light": "Light",
-            "dark": "Dark",
-            "system": "System"
-        },
-        "languages": {
-            "title": "Language",
-            "en": "English",
-            "fr": "French"
+        "toolbar": {
+            "settings": "Settings",
+            "modes": {
+                "title": "Mode",
+                "light": "Light",
+                "dark": "Dark",
+                "system": "System"
+            },
+            "languages": {
+                "title": "Language",
+                "en": "English",
+                "fr": "French"
+            }
         }
-    },
-    "error": {
-        "title": "Something went wrong !",
-        "retry": "Try Again"
     },
     "notFound": {
         "title": "We couldn't find that page",

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,10 +29,6 @@
             }
         }
     },
-    "notFound": {
-        "title": "We couldn't find that page",
-        "goGome": "Return home"
-    },
     "common": {
         "reload": "Reload",
         "loadMore": "Load more",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -29,10 +29,6 @@
             }
         }
     },
-    "notFound": {
-        "title": "Cette page n’existe pas (plus)",
-        "goGome": "Retour à l'accueil"
-    },
     "common": {
         "reload": "Recharger",
         "loadMore": "Charger plus",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,5 @@
 {
-    "header": {
+    "dashboard": {
         "menuEntries": {
             "gamesKey": "Jeux",
             "planningKey": "Planning",
@@ -14,25 +14,20 @@
                 "dlc": "DLCS"
             }
         },
-        "description": "Votre destination privilégiée pour des expériences de jeu passionnantes !"
-    },
-    "toolbar": {
-        "settings": "Paramètres",
-        "modes": {
-            "title": "Mode",
-            "light": "Clair",
-            "dark": "Sombre",
-            "system": "Système"
-        },
-        "languages": {
-            "title": "Langue",
-            "en": "English",
-            "fr": "French"
+        "toolbar": {
+            "settings": "Paramètres",
+            "modes": {
+                "title": "Mode",
+                "light": "Clair",
+                "dark": "Sombre",
+                "system": "Système"
+            },
+            "languages": {
+                "title": "Langue",
+                "en": "English",
+                "fr": "French"
+            }
         }
-    },
-    "error": {
-        "title": "Quelque chose s'est mal passé !",
-        "retry": "Réessayer"
     },
     "notFound": {
         "title": "Cette page n’existe pas (plus)",

--- a/src/app/[locale]/backlog/page.tsx
+++ b/src/app/[locale]/backlog/page.tsx
@@ -1,92 +1,36 @@
-"use client";
-
 // Hooks
-import { useTranslations } from 'next-intl';
-import useMuiXDataGridText from '@/hooks/useMuiXDataGridText';
+import {setRequestLocale , getTranslations} from 'next-intl/server';
 
-// Redux
-import { useGetBacklogQuery } from "@/redux/services/backlogAPI";
+import BacklogViewerClient from '@/components/backlog/BacklogViewerClient';
 
-// Material UI
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
-import type { GridColDef } from '@mui/x-data-grid';
+type Props = {
+  params: Promise<{
+      locale: "en" | "fr"
+  }>
+}
 
-// Others
-import Tooltip from '@mui/material/Tooltip';
-import PlatformColumn from "@/components/tableColumns/platforms";
+export default async function BacklogViewer(props : Props) {
 
-export default function BacklogViewer() {
+    // retrieve locale
+    const params = await props.params;
+    const locale = params.locale;
+
+    // Enable static rendering
+    setRequestLocale(locale);
 
     // Using a query hook automatically fetches data and returns query values
-    const { data, error, isLoading } = useGetBacklogQuery();
-    const customLocaleText = useMuiXDataGridText();
-    const t = useTranslations("backlog");
+    const t = await getTranslations("backlog");
 
-    if (error) {
-        return <>Something bad happened</>
+    const propsClient = {
+      titleLabel: t("columns.title"),
+      platformLabel: t("columns.platform"),
+      notesLabel: t("columns.notes")
     }
 
-    const columns : GridColDef[] = [
-        {
-            field: "title",
-            headerName: t("columns.title"),
-            headerAlign: 'center',
-            renderCell: ({ value }) => (
-              <Tooltip title={value} aria-label={value}>
-                {value}
-              </Tooltip>
-            ),
-            width: 270
-          },
-          {
-            field: "platform",
-            headerName: t("columns.platform"),
-            ...PlatformColumn
-          },
-          {
-            field: "notes",
-            headerName: t("columns.notes"),
-            headerAlign: 'center',
-            renderCell: ({ value }) => (
-              <Tooltip title={value || ""} aria-label={value || ""}>
-                {value || ""}
-              </Tooltip>
-            ),
-            width: 270
-          },
-    ];
-
     return (
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
-          <DataGrid 
-              rows={data} 
-              columns={columns} 
-              disableRowSelectionOnClick 
-              localeText={customLocaleText}
-              slots={{
-                  toolbar: GridToolbar
-              }}
-              slotProps={{
-                  loadingOverlay: {
-                      variant: 'linear-progress',
-                      noRowsVariant: 'skeleton',
-                  }
-              }}
-              loading={isLoading}
-              sortingOrder={['asc', 'desc']}
-              initialState={{
-                  sorting: {
-                      sortModel: [{ field: 'title', sort: 'asc' }],
-                  },
-                  columns: {
-                      columnVisibilityModel: {
-                          // Hide columns notes, the other columns will remain visible
-                          notes: false
-                      }
-                  }
-              }}
-          />
-        </div>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <BacklogViewerClient {...propsClient} />
+      </div>
     )
 
 }

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,7 +1,6 @@
 'use client'; // Error components must be Client Components
 
 // Hooks
-import {useTranslations} from 'next-intl';
 import { useEffect } from 'react'
 
 // Components
@@ -17,8 +16,6 @@ export default function Error({
     reset: () => void
 }) {
   
-    const t = useTranslations('error');
- 
     useEffect(() => {
         // Log the error to an error reporting service
         console.error(error)
@@ -33,8 +30,8 @@ export default function Error({
                 justifyContent: "center",
                 height: "80vh"
             }}>
-            <Typography variant="h4" gutterBottom>{t('title')}</Typography>
-            <Button variant="contained" color="primary" onClick={reset}>{t('retry')}</Button>
+            <Typography variant="h4" gutterBottom>{"Something went wrong !"}</Typography>
+            <Button variant="contained" color="primary" onClick={reset}>{"Try Again"}</Button>
         </Box>
     );
 }

--- a/src/app/[locale]/games/_client/GamesFilters.tsx
+++ b/src/app/[locale]/games/_client/GamesFilters.tsx
@@ -1,24 +1,46 @@
+import { lazy, Suspense } from "react";
+
 // MUI
 import Grid from '@mui/material/Grid2';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CircularProgress from '@mui/material/CircularProgress';
+import SearchIcon from '@mui/icons-material/Search';
 
 // Custom
-import GenresSelect from "@/components/GamesView/GenresSelect";
-import PlatformSelect from "@/components/GamesView/PlatformSelect";
-import TitleFilter from "@/components/GamesView/TitleFilter";
+const GenresSelect = lazy(() => import("@/components/GamesView/GenresSelect"));
+const PlatformSelect = lazy(() => import("@/components/GamesView/PlatformSelect"));
+const TitleFilter = lazy(() => import("@/components/GamesView/TitleFilter"));
 
 export default function GamesFilters() {
 
     return (
-        <Grid container spacing={1}>
-            <Grid size={{ xs: 12, md: 5 }}>
-                <TitleFilter />
-            </Grid>
-            <Grid size={{ xs: 12, md: 3 }}>
-                <PlatformSelect />
-            </Grid>
-            <Grid size={{ xs: 12, md: 4 }}>
-                <GenresSelect />
-            </Grid>
-      </Grid>
-    )
+        <Accordion>
+            <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="panel1-content"
+                id="panel1-header"
+            >
+                <SearchIcon aria-label="Options"/>
+                {"Options"}
+            </AccordionSummary>
+            <AccordionDetails>
+                <Suspense fallback={<CircularProgress />}>
+                    <Grid container spacing={1}>
+                        <Grid size={{ xs: 12, md: 5 }}>
+                            <TitleFilter />
+                        </Grid>
+                        <Grid size={{ xs: 12, md: 3 }}>
+                            <PlatformSelect />
+                        </Grid>
+                        <Grid size={{ xs: 12, md: 4 }}>
+                            <GenresSelect />
+                        </Grid>
+                    </Grid>
+                </Suspense>
+            </AccordionDetails>
+      </Accordion>
+    );
 }

--- a/src/app/[locale]/games/layout.tsx
+++ b/src/app/[locale]/games/layout.tsx
@@ -1,0 +1,22 @@
+import {NextIntlClientProvider} from 'next-intl';
+import {getMessages} from 'next-intl/server';
+
+// Types
+import type { ReactNode } from "react";
+
+type Props = {
+    children: ReactNode
+}
+
+export default async function StatsLaytou({children} : Props) {
+
+    // Providing all messages to the client
+    // side is the easiest way to get started
+    const messages = await getMessages();
+
+    return (
+        <NextIntlClientProvider messages={messages}>
+            {children}
+        </NextIntlClientProvider>
+    );
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -11,10 +11,8 @@ import {setRequestLocale} from 'next-intl/server';
 import {routing} from '@/i18n/routing';
 
 // components
-import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import Box from '@mui/material/Box';
 import DashboardAppProvider from "@/components/dashboard/DashboardAppProvider";
-import ToolbarActions from "@/components/dashboard/ToolbarActions";
 
 // Types
 import type { Metadata } from 'next/types';

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -7,8 +7,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from '@vercel/analytics/react';
 
 // Workaround
-import {NextIntlClientProvider} from 'next-intl';
-import {getMessages} from 'next-intl/server';
+import {setRequestLocale} from 'next-intl/server';
 import {routing} from '@/i18n/routing';
 
 // components
@@ -51,36 +50,26 @@ export default async function RootLayout(props: Props) {
   // To catch with stuff that aren't a locale
   let resolvedLocale = (routing.locales.includes(locale)) ? locale : "fr";
 
-  // Providing all messages to the client
-  // side is the easiest way to get started
-  const messages = await getMessages();
+  // Enable static rendering
+  setRequestLocale(resolvedLocale);
 
   return (
     <html lang={resolvedLocale}>
       <body>
         <StoreProvider>
-          <NextIntlClientProvider locale={resolvedLocale} messages={messages}>
-            <ThemeProvider lng={resolvedLocale}>
-              <DashboardAppProvider>
-                <DashboardLayout 
-                  defaultSidebarCollapsed 
-                  slots={{
-                    toolbarActions: ToolbarActions
-                  }}
-                >
-                  <Box
-                    sx={{
-                      py: 1,
-                      display: 'flex',
-                      flexDirection: 'column'
-                    }}
-                  >
-                    {children}
-                  </Box>
-                </DashboardLayout>
-              </DashboardAppProvider>
-            </ThemeProvider>
-          </NextIntlClientProvider>
+          <ThemeProvider lng={resolvedLocale}>
+            <DashboardAppProvider locale={resolvedLocale} >
+              <Box
+                sx={{
+                  py: 1,
+                  display: 'flex',
+                  flexDirection: 'column'
+                }}
+              >
+                {children}
+              </Box>
+            </DashboardAppProvider>
+          </ThemeProvider>
         </StoreProvider>
         <SpeedInsights />
         <Analytics />

--- a/src/app/[locale]/links/page.tsx
+++ b/src/app/[locale]/links/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 // Components
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,8 +1,7 @@
-"use client";
-
 // https://next-intl-docs.vercel.app/docs/environments/error-files#not-foundjs
 
 // Hooks
+import {setRequestLocale} from 'next-intl/server';
 import {useTranslations} from 'next-intl';
 
 // https://next-intl-docs.vercel.app/docs/routing/navigation
@@ -13,8 +12,18 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 
+type Props = {
+    params: Promise<{
+      locale: "en" | "fr"
+    }>
+  }
 
-export default function NotFoundPage() {
+export default async function NotFoundPage({ params }: Props) {
+
+    const locale = (await params).locale;
+
+    // Enable static rendering
+    setRequestLocale(locale);
 
     const t = useTranslations('notFound');
 

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,9 +1,5 @@
 // https://next-intl-docs.vercel.app/docs/environments/error-files#not-foundjs
 
-// Hooks
-import {setRequestLocale} from 'next-intl/server';
-import {useTranslations} from 'next-intl';
-
 // https://next-intl-docs.vercel.app/docs/routing/navigation
 import { Link } from '@/i18n/routing';
 
@@ -12,20 +8,7 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 
-type Props = {
-    params: Promise<{
-      locale: "en" | "fr"
-    }>
-  }
-
-export default async function NotFoundPage({ params }: Props) {
-
-    const locale = (await params).locale;
-
-    // Enable static rendering
-    setRequestLocale(locale);
-
-    const t = useTranslations('notFound');
+export default async function NotFoundPage() {
 
     return (
         <Box
@@ -36,10 +19,10 @@ export default async function NotFoundPage({ params }: Props) {
                 justifyContent: "center",
                 height: "80vh"
             }}>
-            <Typography variant="h4" gutterBottom>{t('title')}</Typography>
+            <Typography variant="h4" gutterBottom>{"We couldn't find that page"}</Typography>
             <Link href="/">
                 <Button variant="contained" color="primary">
-                    {t('goGome')}
+                    {"Return home"}
                 </Button>
             </Link>
         </Box>

--- a/src/app/[locale]/planning/page.tsx
+++ b/src/app/[locale]/planning/page.tsx
@@ -9,19 +9,9 @@ import { useGetPlanningQuery } from "@/redux/services/planningAPI";
 
 // Material UI
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
-import type { GridColDef } from '@mui/x-data-grid';
 
-// Icons
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-
-// Others
-import Tooltip from '@mui/material/Tooltip';
-import Box from '@mui/material/Box';
-import PlatformColumn from "@/components/tableColumns/platforms";
-
-import type { JSX } from 'react'
-type GameStatus = "RECORDED" | "PENDING";
+// columns
+import generateColumns from "@/components/planning/tableColumns";
 
 export default function PlanningViewer() {
 
@@ -35,81 +25,17 @@ export default function PlanningViewer() {
         return <>Something bad happened</>
     }
     
-    const columns : GridColDef[] = [
-        {
-            field: "title", 
-            headerName: t("columns.title"),
-            headerAlign: 'center',
-            renderCell: ({value}) => (
-                <Tooltip title={value} aria-label={value}>
-                    <div>
-                        {value}
-                    </div>
-                </Tooltip>
-            ),
-            width: 270
-        },
-        {
-            field: "platform",
-            headerName: t("columns.platform"),
-            ...PlatformColumn
-        },
-        {
-            field: "releaseDate", 
-            headerName: t("columns.releaseDate"),
-            headerAlign: 'center',
-            type: 'date',
-            valueGetter: (value) => (value) ? new Date(value) : null,
-            width: 220
-        },
-        {
-            field: "endDate", 
-            headerName: t("columns.endDate"),
-            headerAlign: 'center',
-            type: 'date',
-            valueGetter: (value) => (value) ? new Date(value) : null,
-            width: 220
-        },
-        {
-            field: "status",
-            headerName: t("columns.status"),
-            type: "singleSelect",
-            valueOptions: [
-                { 
-                    value: "RECORDED", 
-                    label: (
-                        <Box
-                            sx={{
-                                display: "flex",
-                                alignItems: "center"
-                            }}>
-                            <CheckCircleIcon />
-                        </Box>
-                    ) 
-                },
-                { 
-                    value: 'PENDING', 
-                    label: (
-                        <Box
-                            sx={{
-                                display: "flex",
-                                alignItems: "center"
-                            }}>
-                            <HourglassEmptyIcon />
-                        </Box>
-                    )
-                }
-            ] satisfies { value: GameStatus; label: JSX.Element }[],
-            renderCell: ({value}) => (
-                <Tooltip title={t(`states.${value as GameStatus}`as const)} aria-label={value}>
-                    { 
-                        (value === "RECORDED") ? <CheckCircleIcon /> : <HourglassEmptyIcon />
-                    }
-                </Tooltip>
-            ),
-            width: 130
+    const columns = generateColumns({
+        endDateLabel: t("columns.endDate"),
+        platformLabel: t("columns.platform"),
+        releaseDateLabel: t("columns.releaseDate"),
+        statusLabel: t("columns.status"),
+        titleLabel: t("columns.title"),
+        statesLabels: {
+            PENDING: t("states.PENDING"),
+            RECORDED: t("states.RECORDED")
         }
-    ];
+    });
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/app/[locale]/planning/page.tsx
+++ b/src/app/[locale]/planning/page.tsx
@@ -1,31 +1,27 @@
-"use client";
+import PlanningViewerClient from "@/components/planning/PlanningViewerClient";
 
 // Hooks
-import { useTranslations } from 'next-intl';
-import useMuiXDataGridText from '@/hooks/useMuiXDataGridText';
+import {setRequestLocale , getTranslations} from 'next-intl/server';
 
-// Redux
-import { useGetPlanningQuery } from "@/redux/services/planningAPI";
+type Props = {
+    params: Promise<{
+        locale: "en" | "fr"
+    }>
+}
 
-// Material UI
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+export default async function PlanningViewer(props : Props) {
 
-// columns
-import generateColumns from "@/components/planning/tableColumns";
+    // retrieve locale
+    const params = await props.params;
+    const locale = params.locale;
 
-export default function PlanningViewer() {
+    // Enable static rendering
+    setRequestLocale(locale);
 
-    // Using a query hook automatically fetches data and returns query values
-
-    const { data, error, isLoading } = useGetPlanningQuery();
-    const customLocaleText = useMuiXDataGridText();
-    const t = useTranslations("planning");
-
-    if (error) {
-        return <>Something bad happened</>
-    }
+    // Retrieve translation
+    const t = await getTranslations("planning");
     
-    const columns = generateColumns({
+    const propsClient = {
         endDateLabel: t("columns.endDate"),
         platformLabel: t("columns.platform"),
         releaseDateLabel: t("columns.releaseDate"),
@@ -35,38 +31,11 @@ export default function PlanningViewer() {
             PENDING: t("states.PENDING"),
             RECORDED: t("states.RECORDED")
         }
-    });
+    };
 
     return (
         <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <DataGrid 
-                rows={data} 
-                columns={columns} 
-                disableRowSelectionOnClick 
-                localeText={customLocaleText}
-                slots={{
-                    toolbar: GridToolbar
-                }}
-                slotProps={{
-                    loadingOverlay: {
-                        variant: 'linear-progress',
-                        noRowsVariant: 'skeleton',
-                    }
-                }}
-                loading={isLoading}
-                sortingOrder={['asc', 'desc']}
-                initialState={{
-                    sorting: {
-                        sortModel: [{ field: 'releaseDate', sort: 'asc' }],
-                    },
-                    columns: {
-                        columnVisibilityModel: {
-                            // Hide columns endDate, the other columns will remain visible
-                            endDate: false
-                        }
-                    }
-                }}
-            />
+            <PlanningViewerClient {...propsClient} />
         </div>
     )
 }

--- a/src/app/[locale]/playlist/[id]/page.tsx
+++ b/src/app/[locale]/playlist/[id]/page.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+export async function generateStaticParams() {
+    const identifiers = (await import("@/app/api/random/identifiers.json")).default;
+    const playlists = identifiers.filter(i => i.playlistId !== undefined);
+
+    return playlists.map((pl) => ({
+        id: pl.playlistId,
+    }));
+}
+
 import { useParams } from 'next/navigation'
 import YTPlayer from "@/components/YTPlayer/Player";
 import RandomButton from '@/components/GamesView/RandomButton';

--- a/src/app/[locale]/playlist/[id]/page.tsx
+++ b/src/app/[locale]/playlist/[id]/page.tsx
@@ -17,7 +17,8 @@ import RandomButton from '@/components/GamesView/RandomButton';
 
 export default async function PlaylistPage({ params } : Props) {
 
-    const id = (await params).id
+    const parameters = await params;
+    const { id } = parameters
     const identifier = id as string;
 
     return (

--- a/src/app/[locale]/playlist/[id]/page.tsx
+++ b/src/app/[locale]/playlist/[id]/page.tsx
@@ -1,3 +1,6 @@
+// Needed because of https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior
+import { Suspense } from 'react'
+
 // https://nextjs.org/docs/app/api-reference/file-conventions/page#props
 type Props = {
     params: Promise<{ id: string }>
@@ -24,7 +27,9 @@ export default async function PlaylistPage({ params } : Props) {
     return (
         <>
             <YTPlayer type="PLAYLIST" identifier={identifier}/>
-            <RandomButton />
+            <Suspense fallback={null}>
+                <RandomButton />
+            </Suspense>
         </>
     )
 }

--- a/src/app/[locale]/playlist/[id]/page.tsx
+++ b/src/app/[locale]/playlist/[id]/page.tsx
@@ -1,4 +1,7 @@
-"use client";
+// https://nextjs.org/docs/app/api-reference/file-conventions/page#props
+type Props = {
+    params: Promise<{ id: string }>
+}
 
 export async function generateStaticParams() {
     const identifiers = (await import("@/app/api/random/identifiers.json")).default;
@@ -9,13 +12,12 @@ export async function generateStaticParams() {
     }));
 }
 
-import { useParams } from 'next/navigation'
 import YTPlayer from "@/components/YTPlayer/Player";
 import RandomButton from '@/components/GamesView/RandomButton';
 
-export default function PlaylistPage() {
+export default async function PlaylistPage({ params } : Props) {
 
-    const { id } = useParams();
+    const id = (await params).id
     const identifier = id as string;
 
     return (

--- a/src/app/[locale]/playlist/[id]/page.tsx
+++ b/src/app/[locale]/playlist/[id]/page.tsx
@@ -1,6 +1,3 @@
-// Needed because of https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior
-import { Suspense } from 'react'
-
 // https://nextjs.org/docs/app/api-reference/file-conventions/page#props
 type Props = {
     params: Promise<{ id: string }>
@@ -27,9 +24,7 @@ export default async function PlaylistPage({ params } : Props) {
     return (
         <>
             <YTPlayer type="PLAYLIST" identifier={identifier}/>
-            <Suspense fallback={null}>
-                <RandomButton />
-            </Suspense>
+            <RandomButton />
         </>
     )
 }

--- a/src/app/[locale]/stats/layout.tsx
+++ b/src/app/[locale]/stats/layout.tsx
@@ -1,0 +1,22 @@
+import {NextIntlClientProvider} from 'next-intl';
+import {getMessages} from 'next-intl/server';
+
+// Types
+import type { ReactNode } from "react";
+
+type Props = {
+    children: ReactNode
+}
+
+export default async function StatsLaytou({children} : Props) {
+
+    // Providing all messages to the client
+    // side is the easiest way to get started
+    const messages = await getMessages();
+
+    return (
+        <NextIntlClientProvider messages={messages}>
+            {children}
+        </NextIntlClientProvider>
+    );
+}

--- a/src/app/[locale]/tests/layout.tsx
+++ b/src/app/[locale]/tests/layout.tsx
@@ -1,0 +1,22 @@
+import {NextIntlClientProvider} from 'next-intl';
+import {getMessages} from 'next-intl/server';
+
+// Types
+import type { ReactNode } from "react";
+
+type Props = {
+    children: ReactNode
+}
+
+export default async function StatsLaytou({children} : Props) {
+
+    // Providing all messages to the client
+    // side is the easiest way to get started
+    const messages = await getMessages();
+
+    return (
+        <NextIntlClientProvider messages={messages}>
+            {children}
+        </NextIntlClientProvider>
+    );
+}

--- a/src/app/[locale]/video/[id]/page.tsx
+++ b/src/app/[locale]/video/[id]/page.tsx
@@ -1,3 +1,6 @@
+// Needed because of https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior
+import { Suspense } from 'react'
+
 // https://nextjs.org/docs/app/api-reference/file-conventions/page#props
 type Props = {
     params: Promise<{ id: string }>
@@ -23,7 +26,9 @@ export default async function PlaylistPage({ params } : Props) {
     return (
         <>
             <YTPlayer type="VIDEO" identifier={identifier}/>
-            <RandomButton />
+            <Suspense fallback={null}>
+                <RandomButton />
+            </Suspense>
         </>
     )
 }

--- a/src/app/[locale]/video/[id]/page.tsx
+++ b/src/app/[locale]/video/[id]/page.tsx
@@ -1,6 +1,3 @@
-// Needed because of https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior
-import { Suspense } from 'react'
-
 // https://nextjs.org/docs/app/api-reference/file-conventions/page#props
 type Props = {
     params: Promise<{ id: string }>
@@ -26,9 +23,7 @@ export default async function PlaylistPage({ params } : Props) {
     return (
         <>
             <YTPlayer type="VIDEO" identifier={identifier}/>
-            <Suspense fallback={null}>
-                <RandomButton />
-            </Suspense>
+            <RandomButton />
         </>
     )
 }

--- a/src/app/[locale]/video/[id]/page.tsx
+++ b/src/app/[locale]/video/[id]/page.tsx
@@ -1,4 +1,7 @@
-"use client";
+// https://nextjs.org/docs/app/api-reference/file-conventions/page#props
+type Props = {
+    params: Promise<{ id: string }>
+}
 
 export async function generateStaticParams() {
     const identifiers = (await import("@/app/api/random/identifiers.json")).default;
@@ -9,13 +12,12 @@ export async function generateStaticParams() {
     }));
 }
 
-import { useParams } from 'next/navigation'
 import YTPlayer from "@/components/YTPlayer/Player";
 import RandomButton from '@/components/GamesView/RandomButton';
 
-export default function PlaylistPage() {
+export default async function PlaylistPage({ params } : Props) {
 
-    const { id } = useParams();
+    const id = (await params).id
     const identifier = id as string;
 
     return (

--- a/src/app/[locale]/video/[id]/page.tsx
+++ b/src/app/[locale]/video/[id]/page.tsx
@@ -1,5 +1,14 @@
 "use client";
 
+export async function generateStaticParams() {
+    const identifiers = (await import("@/app/api/random/identifiers.json")).default;
+    const videos = identifiers.filter(i => i.videoId !== undefined);
+
+    return videos.map((vid) => ({
+        id: vid.videoId,
+    }));
+}
+
 import { useParams } from 'next/navigation'
 import YTPlayer from "@/components/YTPlayer/Player";
 import RandomButton from '@/components/GamesView/RandomButton';

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,9 +8,14 @@ type AvailableRoutes = keyof pathnames;
 // Adapt this as necessary
 const host = 'https://jy95.github.io';
 
+function isStaticPath(path: AvailableRoutes): path is Exclude<AvailableRoutes, `${string}[${string}]`> {
+  return !/\[.+\]/.test(path);
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
     const paths = Object.keys(routing.pathnames) as AvailableRoutes[];
-    return paths.map(getEntry);
+    const staticPaths: Exclude<AvailableRoutes, `${string}[${string}]`>[] = paths.filter(isStaticPath);
+    return staticPaths.map(getEntry);
 }
 
 function getEntry(href: Href): MetadataRoute.Sitemap[number] {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -4,6 +4,7 @@ import {routing, getPathname} from '@/i18n/routing';
 type Href = Parameters<typeof getPathname>[0]['href'];
 type pathnames = typeof routing.pathnames;
 type AvailableRoutes = keyof pathnames;
+type StaticRoute = Exclude<AvailableRoutes, `${string}[${string}]`>;
 
 // Adapt this as necessary
 const host = 'https://jy95.github.io';
@@ -14,7 +15,7 @@ function isStaticPath(path: AvailableRoutes): path is Exclude<AvailableRoutes, `
 
 export default function sitemap(): MetadataRoute.Sitemap {
     const paths = Object.keys(routing.pathnames) as AvailableRoutes[];
-    const staticPaths: Exclude<AvailableRoutes, `${string}[${string}]`>[] = paths.filter(isStaticPath);
+    const staticPaths: StaticRoute[] = paths.filter(isStaticPath);
     return staticPaths.map(getEntry);
 }
 

--- a/src/components/GamesView/CardDialog.tsx
+++ b/src/components/GamesView/CardDialog.tsx
@@ -2,7 +2,7 @@
 
 import { lazy } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter } from 'next/navigation';
+import {useRouter} from '@/i18n/routing';
 import type { MouseEventHandler, JSX } from "react";
 
 // For full screen Dialog 
@@ -48,7 +48,6 @@ function CardDialog(props : {
         title: gameTitle,
         url: gameURL
     } = game;
-    const local_path = game.url_type === "PLAYLIST" ? "/playlist/" + game.id : "/video/" + game.id;
 
     // dialog options
     const dialog_options : {
@@ -66,7 +65,10 @@ function CardDialog(props : {
             onClick: (event) => {
                 event.preventDefault();
                 setContextMenuOpen(false);
-                router.push(`${local_path}`);
+                router.push({
+                    pathname: game.url_type === "PLAYLIST" ? "/playlist/[id]" : "/video/[id]",
+                    params: { id: game.id }
+                })
             }
         },
         // watch on Youtube

--- a/src/components/GamesView/CardEntry.tsx
+++ b/src/components/GamesView/CardEntry.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useState, lazy } from "react";
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
@@ -31,10 +31,12 @@ function CardEntry(props : {
         url_type,
         id: gameId
     } = game;
-    const local_path = url_type === "PLAYLIST" ? "/playlist/" + gameId : "/video/" + gameId;
 
     function watchGame() {
-        router.push(`${local_path}`);
+        router.push({
+            pathname: url_type === "PLAYLIST" ? "/playlist/[id]" : "/video/[id]",
+            params: { id: gameId }
+        });
     }
 
     return (

--- a/src/components/GamesView/RandomButton.tsx
+++ b/src/components/GamesView/RandomButton.tsx
@@ -6,7 +6,7 @@
 import { Suspense } from 'react'
 
 // Hooks
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/routing';
 import { useTranslations } from "next-intl";
 
 // Components
@@ -32,9 +32,10 @@ export function RandomButtonInner() {
     const fetchRandomGame = async () => {
         const response = await fetch('/api/random');
         const data = await response.json() as RandomAnswer;
-        const base_path = data.type === "PLAYLIST" ? "/playlist/" : "/video/";
-        const local_path = base_path + data.identifier;
-        router.push(`${local_path}`);
+        router.push({
+            pathname: data.type === "PLAYLIST" ? "/playlist/[id]" : "/video/[id]",
+            params: { id: data.identifier }
+        });
     }
 
     return (

--- a/src/components/GamesView/RandomButton.tsx
+++ b/src/components/GamesView/RandomButton.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+// Needed because of 
+// https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior
+// https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
+import { Suspense } from 'react'
+
 // Hooks
 import { useRouter } from 'next/navigation';
 import { useTranslations } from "next-intl";
@@ -12,6 +17,14 @@ import CasinoIcon from '@mui/icons-material/Casino';
 import type { RandomAnswer } from "@/app/api/random/route";
 
 export default function RandomButton() {
+    return (
+        <Suspense fallback={null}>
+            <RandomButtonInner />
+        </Suspense>
+    );
+}
+
+export function RandomButtonInner() {
 
     const router = useRouter();
     const t = useTranslations("gamesLibrary");

--- a/src/components/GamesView/RandomButton.tsx
+++ b/src/components/GamesView/RandomButton.tsx
@@ -15,18 +15,13 @@ export default function RandomButton() {
 
     const router = useRouter();
     const t = useTranslations("gamesLibrary");
-    const errorLabels = useTranslations("error");
 
     const fetchRandomGame = async () => {
         const response = await fetch('/api/random');
-        try {
-            const data = await response.json() as RandomAnswer;
-            const base_path = data.type === "PLAYLIST" ? "/playlist/" : "/video/";
-            const local_path = base_path + data.identifier;
-            router.push(`${local_path}`);
-        } catch (err) {
-            alert(errorLabels("title") + " " + errorLabels("retry"));
-        }
+        const data = await response.json() as RandomAnswer;
+        const base_path = data.type === "PLAYLIST" ? "/playlist/" : "/video/";
+        const local_path = base_path + data.identifier;
+        router.push(`${local_path}`);
     }
 
     return (

--- a/src/components/backlog/BacklogViewerClient.tsx
+++ b/src/components/backlog/BacklogViewerClient.tsx
@@ -4,29 +4,26 @@
 import useMuiXDataGridText from '@/hooks/useMuiXDataGridText';
 
 // Redux
-import { useGetPlanningQuery } from "@/redux/services/planningAPI";
+import { useGetBacklogQuery } from "@/redux/services/backlogAPI";
 
-// Material UI
+// Components
 import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import generateColumns from "./tableColumns";
 
-// columns
-import generateColumns from "@/components/planning/tableColumns";
+// Types
+import type { Props as PropsTable } from "./tableColumns";
+type Props = {} & PropsTable;
 
-import type { Props as PropsColumns } from "@/components/planning/tableColumns";
-
-type Props = {} & PropsColumns;
-
-export default function PlanningViewer(props: Props) {
+export default function BacklogViewerClient(props : Props) {
 
     // Using a query hook automatically fetches data and returns query values
-
-    const { data, error, isLoading } = useGetPlanningQuery();
+    const { data, error, isLoading } = useGetBacklogQuery();
     const customLocaleText = useMuiXDataGridText();
 
     if (error) {
         return <>Something bad happened</>
     }
-    
+
     const columns = generateColumns(props);
 
     return (
@@ -48,15 +45,15 @@ export default function PlanningViewer(props: Props) {
             sortingOrder={['asc', 'desc']}
             initialState={{
                 sorting: {
-                    sortModel: [{ field: 'releaseDate', sort: 'asc' }],
+                    sortModel: [{ field: 'title', sort: 'asc' }],
                 },
                 columns: {
                     columnVisibilityModel: {
-                        // Hide columns endDate, the other columns will remain visible
-                        endDate: false
+                        // Hide columns notes, the other columns will remain visible
+                        notes: false
                     }
                 }
             }}
         />
-    )
+    );
 }

--- a/src/components/backlog/tableColumns.tsx
+++ b/src/components/backlog/tableColumns.tsx
@@ -1,0 +1,46 @@
+// Material UI
+import Tooltip from '@mui/material/Tooltip';
+
+// Others
+import PlatformColumn from "@/components/tableColumns/platforms";
+
+// Types
+import type { GridColDef } from '@mui/x-data-grid';
+
+export type Props = {
+    titleLabel: string,
+    platformLabel: string,
+    notesLabel: string
+}
+
+export default function tableColumns(props: Props) : GridColDef[]{
+    return [
+        {
+            field: "title",
+            headerName: props.titleLabel,
+            headerAlign: 'center',
+            renderCell: ({ value }) => (
+              <Tooltip title={value} aria-label={value}>
+                {value}
+              </Tooltip>
+            ),
+            width: 270
+          },
+          {
+            field: "platform",
+            headerName: props.platformLabel,
+            ...PlatformColumn
+          },
+          {
+            field: "notes",
+            headerName: props.notesLabel,
+            headerAlign: 'center',
+            renderCell: ({ value }) => (
+              <Tooltip title={value || ""} aria-label={value || ""}>
+                {value || ""}
+              </Tooltip>
+            ),
+            width: 270
+          },
+    ];
+}

--- a/src/components/dashboard/AppProviderCustom.tsx
+++ b/src/components/dashboard/AppProviderCustom.tsx
@@ -1,0 +1,55 @@
+// Providers
+import { AppProvider } from '@toolpad/core/nextjs';
+
+// Hooks
+import {useTranslations} from 'next-intl';
+
+// components
+import { Suspense } from 'react';
+import NavigationMenu from "./MenuEntries";
+
+// Types
+import type { ReactNode } from 'react';
+type Props = {
+    children: ReactNode
+}
+
+// Needed because of https://nextjs.org/docs/app/api-reference/functions/use-search-params#behavior
+export default function AppProviderCustom(props: Props) {
+    return (
+        <Suspense fallback={<></>}>
+            <AppProviderCustomInner {...props} />
+        </Suspense>
+    )
+}
+
+function AppProviderCustomInner(props: Props) {
+
+    // Fetch labels
+    const t = useTranslations('dashboard');
+
+    // Generate navigation
+    const NAVIGATION = NavigationMenu({
+        backlog: t("menuEntries.backlog"),
+        dlcsView: t("menuEntries.gamesTabs.dlc"),
+        gamesCategoy: t("menuEntries.gamesKey"),
+        gamesView: t("menuEntries.gamesTabs.grid"),
+        links: t("menuEntries.links"),
+        planned: t("menuEntries.planningKey"),
+        seriesView: t("menuEntries.gamesTabs.list"),
+        stats: t("menuEntries.stats"),
+        tests: t("menuEntries.testsKey")
+    });
+
+    return (
+        <AppProvider 
+            navigation={NAVIGATION}
+            branding={{
+                title: "GamesPassionFR",
+                logo: <>&nbsp;</>
+            }}
+        >
+            {props.children}
+        </AppProvider>
+    );
+}

--- a/src/components/dashboard/DashboardAppProvider.tsx
+++ b/src/components/dashboard/DashboardAppProvider.tsx
@@ -1,5 +1,4 @@
 // Providers
-import { AppProvider } from '@toolpad/core/nextjs';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 
 // Hooks
@@ -7,16 +6,14 @@ import {setRequestLocale} from 'next-intl/server';
 import {useTranslations} from 'next-intl';
 
 // components
-import { Suspense } from 'react';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
+import AppProviderCustom from "@/components/dashboard/AppProviderCustom";
 import ToolbarActions from "@/components/dashboard/ToolbarActions";
 
 type Props = {
     children: ReactNode,
     locale: "en" | "fr"
 }
-
-import NavigationMenu from "./MenuEntries";
 
 // Types
 import type { ReactNode } from "react";
@@ -27,31 +24,22 @@ export default function DashboardAppProvider({children, locale} : Props) {
     setRequestLocale(locale);
 
     // Fetch labels
-    const t = useTranslations('dashboard');
+    const t = useTranslations('dashboard.toolbar');
 
-    // Generate navigation
-    const NAVIGATION = NavigationMenu({
-        backlog: t("menuEntries.backlog"),
-        dlcsView: t("menuEntries.gamesTabs.dlc"),
-        gamesCategoy: t("menuEntries.gamesKey"),
-        gamesView: t("menuEntries.gamesTabs.grid"),
-        links: t("menuEntries.links"),
-        planned: t("menuEntries.planningKey"),
-        seriesView: t("menuEntries.gamesTabs.list"),
-        stats: t("menuEntries.stats"),
-        tests: t("menuEntries.testsKey")
-    });
+    const toolbarActionsProps = {
+        settingsLabel: t("settings"),
+        darkLabel: t("modes.dark"),
+        englishLabel: t("languages.en"),
+        frenchLabel: t("languages.fr"),
+        languageTitle: t("languages.title"),
+        lightLabel: t("modes.light"),
+        modeTitle: t("modes.title"),
+        systemLabel: t("modes.system")
+    }
 
     return (
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
-            <Suspense fallback={<></>}>
-                <AppProvider 
-                    navigation={NAVIGATION}
-                    branding={{
-                        title: "GamesPassionFR",
-                        logo: <>&nbsp;</>
-                    }}
-                >
+            <AppProviderCustom>
                 <DashboardLayout 
                     defaultSidebarCollapsed 
                     slots={{
@@ -59,22 +47,12 @@ export default function DashboardAppProvider({children, locale} : Props) {
                         toolbarActions: ToolbarActions
                     }}
                     slotProps={{
-                        toolbarActions: {
-                            settingsLabel: t("toolbar.settings"),
-                            darkLabel: t("toolbar.modes.dark"),
-                            englishLabel: t("toolbar.languages.en"),
-                            frenchLabel: t("toolbar.languages.fr"),
-                            languageTitle: t("toolbar.languages.title"),
-                            lightLabel: t("toolbar.modes.light"),
-                            modeTitle: t("toolbar.modes.title"),
-                            systemLabel: t("toolbar.modes.system")
-                        }
+                        toolbarActions: toolbarActionsProps
                     }}
                 >
                     {children}
                 </DashboardLayout>
-                </AppProvider>
-            </Suspense>
+            </AppProviderCustom>
         </AppRouterCacheProvider>
     );
 }

--- a/src/components/dashboard/DashboardAppProvider.tsx
+++ b/src/components/dashboard/DashboardAppProvider.tsx
@@ -3,81 +3,43 @@ import { AppProvider } from '@toolpad/core/nextjs';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 
 // Hooks
+import {setRequestLocale} from 'next-intl/server';
 import {useTranslations} from 'next-intl';
 
-// Icons
-import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
-import ScheduleIcon from '@mui/icons-material/Schedule';
-import ScienceIcon from '@mui/icons-material/Science';
-import QueryStatsIcon from '@mui/icons-material/QueryStats';
-import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
-import LinkIcon from '@mui/icons-material/Link';
-import AppsIcon from '@mui/icons-material/Apps';
-import ListIcon from '@mui/icons-material/List';
-import ExtensionIcon from '@mui/icons-material/Extension';
+// components
+import { DashboardLayout } from '@toolpad/core/DashboardLayout';
+import ToolbarActions from "@/components/dashboard/ToolbarActions";
+
+type Props = {
+    children: ReactNode,
+    locale: "en" | "fr"
+}
+
+import NavigationMenu from "./MenuEntries";
 
 // Types
-import type { Navigation } from '@toolpad/core/AppProvider';
 import type { ReactNode } from "react";
 
-export default function DashboardAppProvider({
-    children,
-  }: {
-    children: ReactNode
-  }) {
+export default function DashboardAppProvider({children, locale} : Props) {
+
+    // Enable static rendering
+    setRequestLocale(locale);
 
     // Fetch labels
-    const t = useTranslations('header.menuEntries');
+    const t = useTranslations('dashboard');
 
     // Generate navigation
-    const NAVIGATION: Navigation = [
-        {
-            icon: <SportsEsportsIcon />,
-            title: t("gamesKey"),
-            segment: "games",
-            children: [
-                {
-                    icon: <AppsIcon />,
-                    title: t("gamesTabs.grid")
-                },
-                {
-                    segment: "series",
-                    icon: <ListIcon />,
-                    title: t("gamesTabs.list")
-                },
-                {
-                    segment: "dlcs",
-                    icon: <ExtensionIcon />,
-                    title: t("gamesTabs.dlc")
-                }
-            ]
-        },
-        {
-            icon: <ScheduleIcon />,
-            title: t("planningKey"),
-            segment: "planning"
-        },
-        {
-            icon: <HourglassEmptyIcon />,
-            title: t("backlog"),
-            segment: "backlog"
-        },
-        {
-            icon: <ScienceIcon />,
-            title: t("testsKey"),
-            segment: "tests"
-        },
-        {
-            icon: <QueryStatsIcon />,
-            title: t("stats"),
-            segment: "stats"
-        },
-        {
-            icon: <LinkIcon />,
-            title: t("links"),
-            segment: "links"
-        },
-    ];
+    const NAVIGATION = NavigationMenu({
+        backlog: t("menuEntries.backlog"),
+        dlcsView: t("menuEntries.gamesTabs.dlc"),
+        gamesCategoy: t("menuEntries.gamesKey"),
+        gamesView: t("menuEntries.gamesTabs.grid"),
+        links: t("menuEntries.links"),
+        planned: t("menuEntries.planningKey"),
+        seriesView: t("menuEntries.gamesTabs.list"),
+        stats: t("menuEntries.stats"),
+        tests: t("menuEntries.testsKey")
+    });
 
     return (
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
@@ -88,7 +50,27 @@ export default function DashboardAppProvider({
                     logo: <>&nbsp;</>
                 }}
             >
+              <DashboardLayout 
+                defaultSidebarCollapsed 
+                slots={{
+                    // @ts-ignore Type not accurate, will report it to MUI later
+                    toolbarActions: ToolbarActions
+                }}
+                slotProps={{
+                    toolbarActions: {
+                        settingsLabel: t("toolbar.settings"),
+                        darkLabel: t("toolbar.modes.dark"),
+                        englishLabel: t("toolbar.languages.en"),
+                        frenchLabel: t("toolbar.languages.fr"),
+                        languageTitle: t("toolbar.languages.title"),
+                        lightLabel: t("toolbar.modes.light"),
+                        modeTitle: t("toolbar.modes.title"),
+                        systemLabel: t("toolbar.modes.system")
+                    }
+                }}
+              >
                 {children}
+              </DashboardLayout>
             </AppProvider>
         </AppRouterCacheProvider>
     );

--- a/src/components/dashboard/DashboardAppProvider.tsx
+++ b/src/components/dashboard/DashboardAppProvider.tsx
@@ -7,6 +7,7 @@ import {setRequestLocale} from 'next-intl/server';
 import {useTranslations} from 'next-intl';
 
 // components
+import { Suspense } from 'react';
 import { DashboardLayout } from '@toolpad/core/DashboardLayout';
 import ToolbarActions from "@/components/dashboard/ToolbarActions";
 
@@ -43,35 +44,37 @@ export default function DashboardAppProvider({children, locale} : Props) {
 
     return (
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
-            <AppProvider 
-                navigation={NAVIGATION}
-                branding={{
-                    title: "GamesPassionFR",
-                    logo: <>&nbsp;</>
-                }}
-            >
-              <DashboardLayout 
-                defaultSidebarCollapsed 
-                slots={{
-                    // @ts-ignore Type not accurate, will report it to MUI later
-                    toolbarActions: ToolbarActions
-                }}
-                slotProps={{
-                    toolbarActions: {
-                        settingsLabel: t("toolbar.settings"),
-                        darkLabel: t("toolbar.modes.dark"),
-                        englishLabel: t("toolbar.languages.en"),
-                        frenchLabel: t("toolbar.languages.fr"),
-                        languageTitle: t("toolbar.languages.title"),
-                        lightLabel: t("toolbar.modes.light"),
-                        modeTitle: t("toolbar.modes.title"),
-                        systemLabel: t("toolbar.modes.system")
-                    }
-                }}
-              >
-                {children}
-              </DashboardLayout>
-            </AppProvider>
+            <Suspense fallback={<></>}>
+                <AppProvider 
+                    navigation={NAVIGATION}
+                    branding={{
+                        title: "GamesPassionFR",
+                        logo: <>&nbsp;</>
+                    }}
+                >
+                <DashboardLayout 
+                    defaultSidebarCollapsed 
+                    slots={{
+                        // @ts-ignore Type not accurate, will report it to MUI later
+                        toolbarActions: ToolbarActions
+                    }}
+                    slotProps={{
+                        toolbarActions: {
+                            settingsLabel: t("toolbar.settings"),
+                            darkLabel: t("toolbar.modes.dark"),
+                            englishLabel: t("toolbar.languages.en"),
+                            frenchLabel: t("toolbar.languages.fr"),
+                            languageTitle: t("toolbar.languages.title"),
+                            lightLabel: t("toolbar.modes.light"),
+                            modeTitle: t("toolbar.modes.title"),
+                            systemLabel: t("toolbar.modes.system")
+                        }
+                    }}
+                >
+                    {children}
+                </DashboardLayout>
+                </AppProvider>
+            </Suspense>
         </AppRouterCacheProvider>
     );
 }

--- a/src/components/dashboard/LanguageToggle.tsx
+++ b/src/components/dashboard/LanguageToggle.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+// Hooks
+import {usePathname, useRouter} from '@/i18n/routing';
+
+// Components
+import { Suspense } from 'react'
+import Typography from "@mui/material/Typography";
+import ButtonGroup from '@mui/material/ButtonGroup';
+import Button from "@mui/material/Button";
+
+// Types
+import type { Props as CommonProps } from './types';
+type UsedProps = Pick<CommonProps, "frenchLabel" | "englishLabel" | "languageTitle">
+type Props = UsedProps;
+
+// https://next-intl-docs.vercel.app/docs/routing/navigation
+
+export default function LanguageToggle(props: Props) {
+    return (
+        <Suspense fallback={null}>
+            <LanguageToggleInner {...props} />
+        </Suspense>
+    );
+}
+
+function LanguageToggleInner(props: Props) {
+
+    const pathname = usePathname();
+    const router = useRouter();
+
+    const changeLanguage = (locale: string) => () => {
+        router.replace(
+            // @ts-expect-error -- TypeScript will validate that only known `params`
+            // are used in combination with a given `pathname`. Since the two will
+            // always match for the current route, we can skip runtime checks.
+            pathname, 
+            { locale: locale }
+        );
+    }
+
+    return (
+        <>
+            <Typography variant="body1" gutterBottom id="settings-language">
+                {props.languageTitle}
+            </Typography>
+            <ButtonGroup variant="outlined" aria-label={props.languageTitle}>
+                <Button onClick={changeLanguage("fr")} >{props.frenchLabel}</Button>
+                <Button onClick={changeLanguage("en")} >{props.englishLabel}</Button>
+            </ButtonGroup>
+        </>
+    );
+}

--- a/src/components/dashboard/MenuEntries.tsx
+++ b/src/components/dashboard/MenuEntries.tsx
@@ -1,0 +1,75 @@
+// Icons
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import ScienceIcon from '@mui/icons-material/Science';
+import QueryStatsIcon from '@mui/icons-material/QueryStats';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import LinkIcon from '@mui/icons-material/Link';
+import AppsIcon from '@mui/icons-material/Apps';
+import ListIcon from '@mui/icons-material/List';
+import ExtensionIcon from '@mui/icons-material/Extension';
+
+// Types
+import type { Navigation } from '@toolpad/core/AppProvider';
+type Props = {
+    gamesCategoy: string,
+    gamesView: string,
+    seriesView: string,
+    dlcsView: string,
+    planned: string,
+    backlog: string,
+    tests: string,
+    stats: string,
+    links: string
+}
+
+export default function NavigationMenu(props: Props) : Navigation {
+    return [
+        {
+            icon: <SportsEsportsIcon />,
+            title: props.gamesCategoy,
+            segment: "games",
+            children: [
+                {
+                    icon: <AppsIcon />,
+                    title: props.gamesView
+                },
+                {
+                    segment: "series",
+                    icon: <ListIcon />,
+                    title: props.seriesView
+                },
+                {
+                    segment: "dlcs",
+                    icon: <ExtensionIcon />,
+                    title: props.dlcsView
+                }
+            ]
+        },
+        {
+            icon: <ScheduleIcon />,
+            title: props.planned,
+            segment: "planning"
+        },
+        {
+            icon: <HourglassEmptyIcon />,
+            title: props.backlog,
+            segment: "backlog"
+        },
+        {
+            icon: <ScienceIcon />,
+            title: props.tests,
+            segment: "tests"
+        },
+        {
+            icon: <QueryStatsIcon />,
+            title: props.stats,
+            segment: "stats"
+        },
+        {
+            icon: <LinkIcon />,
+            title: props.links,
+            segment: "links"
+        },
+    ]
+}

--- a/src/components/dashboard/ThemeModeToggle.tsx
+++ b/src/components/dashboard/ThemeModeToggle.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+// Hooks
+import { useColorScheme } from '@mui/material/styles';
+
+// Components
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
+import ToggleButton from '@mui/material/ToggleButton';
+import Typography from "@mui/material/Typography";
+
+// Icons
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
+import SettingsBrightnessIcon from '@mui/icons-material/SettingsBrightness';
+
+// Types
+import type { MouseEvent } from "react";
+import type { Props as CommonProps } from './types';
+type UsedProps = Pick<CommonProps, "modeTitle" | "darkLabel" | "lightLabel" | "systemLabel">
+type Props = UsedProps;
+
+export default function ThemeMode(props: Props) {
+
+    const { mode, setMode } = useColorScheme();
+
+    const handleChangeThemeMode = (_event : MouseEvent<HTMLElement>, paletteMode : any) => {
+        if (paletteMode === null) {
+          return;
+        }
+        setMode(paletteMode);
+    };
+
+    return (
+        <>
+            <Typography variant="body1" gutterBottom id="settings-mode">
+                {props.modeTitle}
+            </Typography>
+            <ToggleButtonGroup
+                exclusive
+                value={mode}
+                color="primary"
+                onChange={handleChangeThemeMode}
+                aria-labelledby="settings-mode"
+                fullWidth
+            >
+
+                <ToggleButton
+                    value="light"
+                    aria-label={props.lightLabel}
+                >
+                    <LightModeIcon fontSize="small" />
+                    {props.lightLabel}
+                </ToggleButton>
+
+                <ToggleButton
+                    value="system"
+                    aria-label={props.systemLabel}
+                >
+                    <SettingsBrightnessIcon fontSize="small" />
+                    {props.systemLabel}
+                </ToggleButton>
+
+                <ToggleButton
+                    value="dark"
+                    aria-label={props.darkLabel}
+                >
+                    <DarkModeOutlinedIcon fontSize="small" />
+                    {props.darkLabel}
+                </ToggleButton>
+
+            </ToggleButtonGroup>
+        </>
+    );
+
+}

--- a/src/components/dashboard/ToolbarActions.tsx
+++ b/src/components/dashboard/ToolbarActions.tsx
@@ -4,7 +4,6 @@
 import dynamic from 'next/dynamic'
 import { useState, Suspense } from "react";
 import { useColorScheme } from '@mui/material/styles';
-import { useTranslations } from 'next-intl';
 import { Link, usePathname } from '@/i18n/routing';
 
 // Components
@@ -26,12 +25,23 @@ const SettingsBrightnessIcon = dynamic(() => import('@mui/icons-material/Setting
 // https://mui.com/toolpad/core/react-dashboard-layout/#slots
 // https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually
 
-export default function ToolbarActions(){
+// Labels
+type Props = {
+    settingsLabel: string,
+    modeTitle: string,
+    lightLabel: string,
+    darkLabel: string,
+    systemLabel: string,
+    languageTitle: string,
+    frenchLabel: string,
+    englishLabel: string
+}
+
+export default function ToolbarActions(props: Props){
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const { mode, setMode } = useColorScheme();
     const pathname = usePathname();
-    const t = useTranslations("toolbar");
 
     const toggleMenu = () => setIsMenuOpen((previousIsMenuOpen) => !previousIsMenuOpen);
 
@@ -44,7 +54,7 @@ export default function ToolbarActions(){
 
     return (
         <>
-            <IconButton aria-label={t("settings")} onClick={toggleMenu}>
+            <IconButton aria-label={props.settingsLabel} onClick={toggleMenu}>
                 <SettingsIcon />
             </IconButton>
             <Suspense fallback={null}>
@@ -56,7 +66,7 @@ export default function ToolbarActions(){
                     <Box sx={{ pl: 2, pr: 2, py: 10 }}>
 
                         <Typography variant="body1" gutterBottom id="settings-mode">
-                            {t("modes.title")}
+                            {props.modeTitle}
                         </Typography>
                         <ToggleButtonGroup
                             exclusive
@@ -69,39 +79,39 @@ export default function ToolbarActions(){
 
                             <ToggleButton
                                 value="light"
-                                aria-label={t('modes.light')}
+                                aria-label={props.lightLabel}
                             >
                                 <LightModeIcon fontSize="small" />
-                                {t('modes.light')}
+                                {props.lightLabel}
                             </ToggleButton>
 
                             <ToggleButton
                                 value="system"
-                                aria-label={t('modes.system')}
+                                aria-label={props.systemLabel}
                             >
                                 <SettingsBrightnessIcon fontSize="small" />
-                                {t('modes.system')}
+                                {props.systemLabel}
                             </ToggleButton>
 
                             <ToggleButton
                                 value="dark"
-                                aria-label={t('modes.dark')}
+                                aria-label={props.darkLabel}
                             >
                                 <DarkModeOutlinedIcon fontSize="small" />
-                                {t('modes.dark')}
+                                {props.darkLabel}
                             </ToggleButton>
 
                         </ToggleButtonGroup>
 
                         <Typography variant="body1" gutterBottom id="settings-language">
-                            {t("languages.title")}
+                            {props.languageTitle}
                         </Typography>
-                        <ButtonGroup variant="outlined" aria-label={t("languages.title")}>
+                        <ButtonGroup variant="outlined" aria-label={props.languageTitle}>
                             <Link href={pathname} locale={"fr"}>
-                                <Button>{t("languages.fr")}</Button>
+                                <Button>{props.frenchLabel}</Button>
                             </Link>
                             <Link href={pathname} locale={"en"}>
-                                <Button>{t("languages.en")}</Button>
+                                <Button>{props.englishLabel}</Button>
                             </Link>
                         </ButtonGroup>
                     </Box>

--- a/src/components/dashboard/ToolbarActions.tsx
+++ b/src/components/dashboard/ToolbarActions.tsx
@@ -3,54 +3,27 @@
 // Hooks
 import dynamic from 'next/dynamic'
 import { useState, Suspense } from "react";
-import { useColorScheme } from '@mui/material/styles';
-import { Link, usePathname } from '@/i18n/routing';
 
 // Components
+import IconButton from '@mui/material/IconButton';
+const ThemeMode = dynamic(() => import("./ThemeModeToggle"));
+const LanguageToggle = dynamic(() => import("./LanguageToggle")); 
 const Drawer = dynamic(() => import('@mui/material/Drawer'));
 const Box = dynamic(() => import('@mui/material/Box'));
-import IconButton from '@mui/material/IconButton';
-import Typography from "@mui/material/Typography";
-const ToggleButtonGroup = dynamic(() => import('@mui/material/ToggleButtonGroup'));
-const ToggleButton = dynamic(() => import('@mui/material/ToggleButton'));
-const Button = dynamic(() => import('@mui/material/Button'));
-const ButtonGroup = dynamic(() => import('@mui/material/ButtonGroup'));
 
 // Icons
 import SettingsIcon from '@mui/icons-material/Settings';
-const LightModeIcon = dynamic(() => import('@mui/icons-material/LightMode'));
-const DarkModeOutlinedIcon = dynamic(() => import('@mui/icons-material/DarkModeOutlined'));
-const SettingsBrightnessIcon = dynamic(() => import('@mui/icons-material/SettingsBrightness'));
 
 // https://mui.com/toolpad/core/react-dashboard-layout/#slots
 // https://mui.com/material-ui/customization/css-theme-variables/configuration/#toggling-dark-mode-manually
 
 // Labels
-type Props = {
-    settingsLabel: string,
-    modeTitle: string,
-    lightLabel: string,
-    darkLabel: string,
-    systemLabel: string,
-    languageTitle: string,
-    frenchLabel: string,
-    englishLabel: string
-}
+import type { Props } from './types';
 
 export default function ToolbarActions(props: Props){
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
-    const { mode, setMode } = useColorScheme();
-    const pathname = usePathname();
-
     const toggleMenu = () => setIsMenuOpen((previousIsMenuOpen) => !previousIsMenuOpen);
-
-    const handleChangeThemeMode = (event : any, paletteMode : any) => {
-        if (paletteMode === null) {
-          return;
-        }
-        setMode(paletteMode);
-    };
 
     return (
         <>
@@ -64,56 +37,8 @@ export default function ToolbarActions(props: Props){
                     anchor="right"
                 >
                     <Box sx={{ pl: 2, pr: 2, py: 10 }}>
-
-                        <Typography variant="body1" gutterBottom id="settings-mode">
-                            {props.modeTitle}
-                        </Typography>
-                        <ToggleButtonGroup
-                            exclusive
-                            value={mode}
-                            color="primary"
-                            onChange={handleChangeThemeMode}
-                            aria-labelledby="settings-mode"
-                            fullWidth
-                        >
-
-                            <ToggleButton
-                                value="light"
-                                aria-label={props.lightLabel}
-                            >
-                                <LightModeIcon fontSize="small" />
-                                {props.lightLabel}
-                            </ToggleButton>
-
-                            <ToggleButton
-                                value="system"
-                                aria-label={props.systemLabel}
-                            >
-                                <SettingsBrightnessIcon fontSize="small" />
-                                {props.systemLabel}
-                            </ToggleButton>
-
-                            <ToggleButton
-                                value="dark"
-                                aria-label={props.darkLabel}
-                            >
-                                <DarkModeOutlinedIcon fontSize="small" />
-                                {props.darkLabel}
-                            </ToggleButton>
-
-                        </ToggleButtonGroup>
-
-                        <Typography variant="body1" gutterBottom id="settings-language">
-                            {props.languageTitle}
-                        </Typography>
-                        <ButtonGroup variant="outlined" aria-label={props.languageTitle}>
-                            <Link href={pathname} locale={"fr"}>
-                                <Button>{props.frenchLabel}</Button>
-                            </Link>
-                            <Link href={pathname} locale={"en"}>
-                                <Button>{props.englishLabel}</Button>
-                            </Link>
-                        </ButtonGroup>
+                        <ThemeMode {...props} />
+                        <LanguageToggle {...props} />
                     </Box>
                 </Drawer>
             </Suspense>

--- a/src/components/dashboard/types.tsx
+++ b/src/components/dashboard/types.tsx
@@ -1,0 +1,11 @@
+// Common types used in dashboard
+export type Props = {
+    settingsLabel: string,
+    modeTitle: string,
+    lightLabel: string,
+    darkLabel: string,
+    systemLabel: string,
+    languageTitle: string,
+    frenchLabel: string,
+    englishLabel: string
+}

--- a/src/components/planning/PlanningViewerClient.tsx
+++ b/src/components/planning/PlanningViewerClient.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// Hooks
+import useMuiXDataGridText from '@/hooks/useMuiXDataGridText';
+
+// Redux
+import { useGetPlanningQuery } from "@/redux/services/planningAPI";
+
+// Material UI
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+
+// columns
+import generateColumns from "@/components/planning/tableColumns";
+
+import type { Props as PropsColumns } from "@/components/planning/tableColumns";
+
+type Props = {} & PropsColumns;
+
+export default function PlanningViewer(props: Props) {
+
+    // Using a query hook automatically fetches data and returns query values
+
+    const { data, error, isLoading } = useGetPlanningQuery();
+    const customLocaleText = useMuiXDataGridText();
+
+    if (error) {
+        return <>Something bad happened</>
+    }
+    
+    const columns = generateColumns(props);
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <DataGrid 
+                rows={data} 
+                columns={columns} 
+                disableRowSelectionOnClick 
+                localeText={customLocaleText}
+                slots={{
+                    toolbar: GridToolbar
+                }}
+                slotProps={{
+                    loadingOverlay: {
+                        variant: 'linear-progress',
+                        noRowsVariant: 'skeleton',
+                    }
+                }}
+                loading={isLoading}
+                sortingOrder={['asc', 'desc']}
+                initialState={{
+                    sorting: {
+                        sortModel: [{ field: 'releaseDate', sort: 'asc' }],
+                    },
+                    columns: {
+                        columnVisibilityModel: {
+                            // Hide columns endDate, the other columns will remain visible
+                            endDate: false
+                        }
+                    }
+                }}
+            />
+        </div>
+    )
+}

--- a/src/components/planning/tableColumns.tsx
+++ b/src/components/planning/tableColumns.tsx
@@ -15,7 +15,7 @@ import type { GridColDef } from '@mui/x-data-grid';
 
 type GameStatus = "RECORDED" | "PENDING";
 
-type Props = {
+export type Props = {
     titleLabel: string,
     platformLabel: string,
     releaseDateLabel: string,

--- a/src/components/planning/tableColumns.tsx
+++ b/src/components/planning/tableColumns.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+// Icons
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+
+// Others
+import Tooltip from '@mui/material/Tooltip';
+import Box from '@mui/material/Box';
+import PlatformColumn from "@/components/tableColumns/platforms";
+
+// Types
+import type { JSX } from "react";
+import type { GridColDef } from '@mui/x-data-grid';
+
+type GameStatus = "RECORDED" | "PENDING";
+
+type Props = {
+    titleLabel: string,
+    platformLabel: string,
+    releaseDateLabel: string,
+    endDateLabel: string,
+    statusLabel: string,
+    statesLabels: Record<GameStatus, string>
+}
+
+export default function tableColumns(props: Props) : GridColDef[]{
+    return [
+        {
+            field: "title", 
+            headerName: props.titleLabel,
+            headerAlign: 'center',
+            renderCell: ({value}) => (
+                <Tooltip title={value} aria-label={value}>
+                    <div>
+                        {value}
+                    </div>
+                </Tooltip>
+            ),
+            width: 270
+        },
+        {
+            field: "platform",
+            headerName: props.platformLabel,
+            ...PlatformColumn
+        },
+        {
+            field: "releaseDate", 
+            headerName: props.releaseDateLabel,
+            headerAlign: 'center',
+            type: 'date',
+            valueGetter: (value) => (value) ? new Date(value) : null,
+            width: 220
+        },
+        {
+            field: "endDate", 
+            headerName: props.endDateLabel,
+            headerAlign: 'center',
+            type: 'date',
+            valueGetter: (value) => (value) ? new Date(value) : null,
+            width: 220
+        },
+        {
+            field: "status",
+            headerName: props.statusLabel,
+            type: "singleSelect",
+            valueOptions: [
+                { 
+                    value: "RECORDED", 
+                    label: (
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center"
+                            }}>
+                            <CheckCircleIcon />
+                        </Box>
+                    ) 
+                },
+                { 
+                    value: 'PENDING', 
+                    label: (
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center"
+                            }}>
+                            <HourglassEmptyIcon />
+                        </Box>
+                    )
+                }
+            ] satisfies { value: GameStatus; label: JSX.Element }[],
+            renderCell: ({value}) => (
+                <Tooltip title={props.statesLabels[value as GameStatus]} aria-label={value}>
+                    { 
+                        (value === "RECORDED") ? <CheckCircleIcon /> : <HourglassEmptyIcon />
+                    }
+                </Tooltip>
+            ),
+            width: 130
+        }
+    ]
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -16,7 +16,10 @@ export const routing = defineRouting({
     '/backlog': '/backlog',
     '/tests': '/tests',
     '/stats': '/stats',
-    '/links': '/links'
+    '/links': '/links',
+    // Dynamic params are supported via square brackets
+    '/playlist/[id]': '/playlist/[id]',
+    '/video/[id]': '/video/[id]'
   }
 });
  


### PR DESCRIPTION
Idea I got on https://howlongtobeat.com/

For the custom browerlist : 
- https://nextjs.org/docs/architecture/supported-browsers#browserslist
- https://browsersl.ist/
- https://mui.com/material-ui/getting-started/supported-platforms/
- https://ionicframework.com/docs/reference/browser-support