### PR TITLE
feat: add random game feature  in menu

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -11,7 +11,8 @@
             "gamesTabs": {
                 "grid": "Games",
                 "list": "Series",
-                "dlc": "DLCS"
+                "dlc": "DLCS",
+                "random": "Random"
             }
         },
         "toolbar": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -11,7 +11,8 @@
             "gamesTabs": {
                 "grid": "Jeux",
                 "list": "Séries",
-                "dlc": "DLCS"
+                "dlc": "DLCS",
+                "random": "Au hasard"
             }
         },
         "toolbar": {

--- a/src/app/[locale]/games/random/page.tsx
+++ b/src/app/[locale]/games/random/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+// Hooks
+import { useRouter } from '@/i18n/routing';
+import { useEffect } from 'react'
+
+export default function Random() {
+    const router = useRouter();
+
+    const fetchRandomGame = async () => {
+        const response = await fetch('/api/random');
+        const data = await response.json();
+        router.push({
+            pathname: data.type === "PLAYLIST" ? "/playlist/[id]" : "/video/[id]",
+            params: { id: data.identifier }
+        });
+    }
+
+    useEffect(() => {
+        fetchRandomGame();
+    }, []);
+
+    return (<></>);
+}

--- a/src/components/dashboard/AppProviderCustom.tsx
+++ b/src/components/dashboard/AppProviderCustom.tsx
@@ -34,6 +34,7 @@ function AppProviderCustomInner(props: Props) {
         dlcsView: t("menuEntries.gamesTabs.dlc"),
         gamesCategoy: t("menuEntries.gamesKey"),
         gamesView: t("menuEntries.gamesTabs.grid"),
+        randomView: t("menuEntries.gamesTabs.random"),
         links: t("menuEntries.links"),
         planned: t("menuEntries.planningKey"),
         seriesView: t("menuEntries.gamesTabs.list"),

--- a/src/components/dashboard/MenuEntries.tsx
+++ b/src/components/dashboard/MenuEntries.tsx
@@ -8,6 +8,7 @@ import LinkIcon from '@mui/icons-material/Link';
 import AppsIcon from '@mui/icons-material/Apps';
 import ListIcon from '@mui/icons-material/List';
 import ExtensionIcon from '@mui/icons-material/Extension';
+import CasinoIcon from '@mui/icons-material/Casino';
 
 // Types
 import type { Navigation } from '@toolpad/core/AppProvider';
@@ -16,6 +17,7 @@ type Props = {
     gamesView: string,
     seriesView: string,
     dlcsView: string,
+    randomView: string,
     planned: string,
     backlog: string,
     tests: string,
@@ -43,6 +45,11 @@ export default function NavigationMenu(props: Props) : Navigation {
                     segment: "dlcs",
                     icon: <ExtensionIcon />,
                     title: props.dlcsView
+                },
+                {
+                    segment: "random",
+                    icon: <CasinoIcon />,
+                    title: props.randomView
                 }
             ]
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Random" tab to the games section in the dashboard menu, allowing users to access a random playlist or video.
  - Introduced navigation that automatically redirects users to a random playlist or video when selecting the "Random" option.
- **Localization**
  - Added English and French translations for the new "Random" tab in the dashboard menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->