### PR TITLE
Order backlog entries by title in SQL query

### DIFF
--- a/scripts/extractors/tier-list-backlog.ts
+++ b/scripts/extractors/tier-list-backlog.ts
@@ -28,7 +28,8 @@ export async function extractAndSaveTierListBacklog(db: Database, outputPath: st
         SELECT b.*, COALESCE(tc.slug, 'tier_not_evaluated') AS category_slug
         FROM backlog b
         LEFT JOIN tier_list_backlog tlb ON b.id = tlb.backlog_id
-        LEFT JOIN tier_categories tc ON tlb.category_id = tc.id
+        LEFT JOIN tier_categories tc ON tlb.category_id = tc.id 
+        ORDER BY b.title ASC
     `).all() as TierListBacklogEntry[];
 
     // 3. Fill the result object

--- a/scripts/extractors/tier-list-games.ts
+++ b/scripts/extractors/tier-list-games.ts
@@ -37,7 +37,8 @@ export async function extractAndSaveTierListGames(db: Database, outputPath: stri
         FROM games_in_present g
         LEFT JOIN tier_list_games tlg ON g.id = tlg.game_id
         LEFT JOIN tier_categories tc ON tlg.category_id = tc.id
-        WHERE g.id NOT IN (SELECT dlc FROM games_dlcs)
+        WHERE g.id NOT IN (SELECT dlc FROM games_dlcs) 
+        ORDER BY g.title ASC
     `).all() as GameRow[];
 
     // 3. Fill the result object


### PR DESCRIPTION
Added ordering to the SQL query results by title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tier list backlog items are now sorted alphabetically by title for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->