### PR TITLE
refactor: adding a redirect from /tier to /tier/games

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,11 @@ const nextConfig: NextConfig = {
                 source: "/tier",
                 destination: "/tier/games",
                 permanent: false
+            },
+            {
+                source: "/:locale/tier",
+                destination: "/:locale/tier/games",
+                permanent: false
             }
         ]
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,11 @@ const nextConfig: NextConfig = {
                 source: "/",
                 destination: "/games",
                 permanent: false
+            },
+            {
+                source: "/tier",
+                destination: "/tier/games",
+                permanent: false
             }
         ]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-permanent redirect from `/tier` to `/tier/games` (and `/:locale/tier` to `/:locale/tier/games`) for easier navigation.

* **Bug Fixes**
  * Requests to `/tier` now route to the expected destination without changing other site behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->