### PR TITLE
refactor: skip empty categories for test tier lists

### DIFF
--- a/src/app/[locale]/tier/tests/page.tsx
+++ b/src/app/[locale]/tier/tests/page.tsx
@@ -20,7 +20,8 @@ export default function GamesTierList() {
         <TierLists 
             data={data}
             isLoadingData={isLoading}
-            GameRender={GameCardRenderer}
+            GameRender={GameCardRenderer} 
+            skipEmptyCategories={true}
         />
     );
 }

--- a/src/components/tierList/TierListBoard.tsx
+++ b/src/components/tierList/TierListBoard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import Box from "@mui/material/Box";
 import { TierRow } from "./TierRow";
 import type { RawType, GameRender, BackgroundColor } from "./index";
@@ -9,17 +10,25 @@ interface TierListBoardProps<T extends RawType> {
     data: Record<string, T[]>;
     categoryColors: Record<string, BackgroundColor>;
     GameRender: GameRender<T>;
+    skipEmptyCategories?: boolean;
 }
 
 export function TierListBoard<T extends RawType>({ 
     categories, 
     data, 
     categoryColors, 
-    GameRender 
+    GameRender,
+    skipEmptyCategories = false
 }: TierListBoardProps<T>) {
+
+    const visibleCategories = useMemo(() => {
+        if (!skipEmptyCategories) return categories;
+        return categories.filter((slug) => data[slug] && data[slug].length > 0);
+    }, [categories, data, skipEmptyCategories]);
+
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-            {categories.map((categorySlug) => {
+            {visibleCategories.map((categorySlug) => {
                 const itemsForCategory = data[categorySlug] || [];
                 const slugColor = categoryColors[categorySlug] || "grey";
 

--- a/src/components/tierList/TierLists.tsx
+++ b/src/components/tierList/TierLists.tsx
@@ -18,6 +18,7 @@ export interface TierListsProps<T extends RawType> {
     isLoadingData?: boolean;
     GameRender: GameRender<T>;
     categoryColors?: Record<string, BackgroundColor>;
+    skipEmptyCategories?: boolean;
 }
 
 export function TierLists<T extends RawType>({ 
@@ -32,7 +33,8 @@ export function TierLists<T extends RawType>({
         'tier_poor': '#4D96FF',           // blue
         'tier_bad': '#9D4EDD',            // purple
         'tier_not_evaluated': '#A0A0A0',  
-    }
+    },
+    skipEmptyCategories = false,
 }: TierListsProps<T>) {
 
     // local state for sorting
@@ -72,6 +74,7 @@ export function TierLists<T extends RawType>({
                 data={data}
                 categoryColors={categoryColors}
                 GameRender={GameRender}
+                skipEmptyCategories={skipEmptyCategories}
             />
         </>
     )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to hide empty categories from tier lists.
  * The games tier list now displays only categories containing games, creating a more streamlined view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->