### PR TITLE
Add cover image functionality for games

### DIFF
--- a/.github/workflows/issuesAutomatedTasks.yml
+++ b/.github/workflows/issuesAutomatedTasks.yml
@@ -143,33 +143,7 @@ jobs:
           - name: 💻 Install npm packages
             #run: npm ci
             run: npm install
-          - name: 📕 Add cover
-            if: ${{ env.OPERATION == 'ADD_COVER' }}
-            run: |
-              # Extract URL and folder path from the JSON environment variable
-              REQUEST_URL=$(echo $REQUEST | jq -r '.imageURL')
-              REQUEST_FOLDER=$(echo $REQUEST | jq -r '.folder[0]')
-              REQUEST_ID=$(echo $REQUEST | jq -r '.identifierValue')
-
-              # Define the folder path variable
-              FOLDER_PATH="./public/$REQUEST_FOLDER/$REQUEST_ID"  
-              FILE_PATH="$FOLDER_PATH/cover.webp"
-
-              # Delete the target folder (if existing)
-              sudo rm -rf "$FOLDER_PATH"
-
-              # Create the target folder
-              sudo mkdir -p "$FOLDER_PATH"
-
-              # Download the image without worrying about the extension
-              curl -L -o image_file "$REQUEST_URL"
-
-              # Resize the image and convert to WebP format using npx sharp-cli
-              sudo npx --yes sharp-cli -i ./image_file -o "$FILE_PATH" -f webp resize 250 250 --fit inside
-
-              # Clean up the original file
-              sudo rm image_file
-          - name: 💿 Do actions in database
+          - name: 💿 Do requested action
             run: |
                 npx tsx scripts/automatedTasks.ts "$OPERATION" "$REQUEST"
           - name: 🤖 Update JSON files after this change

--- a/scripts/automatedTasks.ts
+++ b/scripts/automatedTasks.ts
@@ -91,10 +91,14 @@ const taskMap: Record<TaskType, TaskHandler> = {
         await updateTierLists(db, payload);
     },
 
-    // Copy Covers
+    // Covers
     COPY_COVERS: async (db, payload) => {
         const { copyCovers } = await import('./tasks');
         await copyCovers(db, payload);
+    },
+    ADD_COVER: async (db, payload) => {
+        const { addCover } = await import('./tasks');
+        await addCover(db, payload);
     },
 };
 

--- a/scripts/tasks/add-cover.ts
+++ b/scripts/tasks/add-cover.ts
@@ -80,7 +80,7 @@ async function convertAndResizeImage(
  * 3. Download the image from the provided URL
  * 4. Convert and resize to WebP format (250x250)
  */
-export async function addCoverToDatabase(
+export async function addCover(
   _db: Database,
   payload: AddCoverPayload
 ): Promise<void> {

--- a/scripts/tasks/add-cover.ts
+++ b/scripts/tasks/add-cover.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
-import { mkdir, rm } from 'fs/promises';
+import { dirname, resolve, normalize, relative } from 'path';
+import { mkdir, rm, rename } from 'fs/promises';
+import { randomBytes } from 'crypto';
 import sharp from 'sharp';
 
 import type { Database } from 'better-sqlite3';
@@ -27,6 +28,37 @@ const allowedFolders = new Set<Folder>([
 function validateFolder(folder: string): asserts folder is Folder {
   if (!allowedFolders.has(folder as Folder)) {
     throw new Error(`Invalid folder name: ${folder}`);
+  }
+}
+
+/**
+ * Validates an identifier value to prevent path traversal attacks.
+ * Rejects empty values, absolute paths, and paths that would escape the folder root.
+ * @param identifierValue The identifier value to validate.
+ * @param folderRoot The root directory that the identifier must stay within.
+ */
+function validateIdentifier(identifierValue: string, folderRoot: string): void {
+  // Reject empty values
+  if (!identifierValue || identifierValue.trim() === '') {
+    throw new Error('Identifier value cannot be empty');
+  }
+
+  // Normalize and resolve the full path
+  const resolvedPath = resolve(folderRoot, identifierValue);
+  const normalizedPath = normalize(resolvedPath);
+
+  // Get the relative path from folderRoot to the resolved path
+  const relativePath = relative(folderRoot, normalizedPath);
+
+  // Check if the path escapes the folder root
+  // If it starts with '..' or is an absolute path outside folderRoot, it's invalid
+  if (relativePath.startsWith('..') || resolve(folderRoot, relativePath) !== normalizedPath) {
+    throw new Error(`Invalid identifier value: path traversal detected in "${identifierValue}"`);
+  }
+
+  // Additional check: reject absolute paths
+  if (resolve(identifierValue) === normalize(identifierValue)) {
+    throw new Error(`Invalid identifier value: absolute paths not allowed "${identifierValue}"`);
   }
 }
 
@@ -73,12 +105,16 @@ async function convertAndResizeImage(
 
 /**
  * Adds a cover image for a game or backlog entry.
- * 
+ *
  * Process:
- * 1. Validate the folder parameter
- * 2. Create/recreate the target folder structure
+ * 1. Validate the folder parameter and identifier value
+ * 2. Create a staging directory for the new cover
  * 3. Download the image from the provided URL
  * 4. Convert and resize to WebP format (250x250)
+ * 5. Atomically replace the original folder with the staging directory
+ *
+ * This approach ensures the original cover is never deleted before the replacement
+ * succeeds, preventing data loss on failure.
  */
 export async function addCover(
   _db: Database,
@@ -95,39 +131,61 @@ export async function addCover(
 
   // Define paths
   const publicPath = resolve(__dirname, '..', '..', 'public');
-  const folderPath = resolve(publicPath, folder, identifierValue);
-  const filePath = resolve(folderPath, 'cover.webp');
+  const folderRoot = resolve(publicPath, folder);
+
+  // Validate identifier before constructing paths
+  validateIdentifier(identifierValue, folderRoot);
+
+  const folderPath = resolve(folderRoot, identifierValue);
+
+  // Create a unique staging directory (sibling to target, not inside it)
+  const stagingDirName = `.staging-${identifierValue}-${randomBytes(8).toString('hex')}`;
+  const stagingPath = resolve(folderRoot, stagingDirName);
+  const stagingFilePath = resolve(stagingPath, 'cover.webp');
+
+  let shouldCleanupStaging = true;
 
   try {
     console.log(`📁 Processing cover for ${folder}/${identifierValue}...`);
 
-    // Delete existing folder if it exists
-    try {
-      console.log(`🗑️  Removing existing folder...`);
-      await rm(folderPath, { recursive: true, force: true });
-    } catch {
-      // Folder doesn't exist, which is fine
-    }
-
-    // Create target folder
-    console.log(`📂 Creating folder...`);
-    await mkdir(folderPath, { recursive: true });
+    // Create staging directory
+    console.log(`📂 Creating staging directory...`);
+    await mkdir(stagingPath, { recursive: true });
 
     // Download the image
     console.log(`⬇️  Downloading image from ${imageURL}...`);
     const imageBuffer = await downloadImage(imageURL);
 
-    // Convert and resize to WebP
+    // Convert and resize to WebP in staging directory
     console.log(`🔄 Converting and resizing image to WebP (250x250)...`);
-    await convertAndResizeImage(imageBuffer, filePath);
+    await convertAndResizeImage(imageBuffer, stagingFilePath);
 
-    console.log(`✅ Cover added successfully: ${filePath}`);
-  } catch (error) {
-    // Clean up on error
+    // Successfully created the new cover in staging directory
+    // Now perform the atomic swap - this is in a separate try/catch to preserve staging on swap failure
+    console.log(`🔄 Replacing original folder with new cover...`);
+
     try {
+      // Remove the original folder if it exists
       await rm(folderPath, { recursive: true, force: true });
-    } catch {
-      // Ignore cleanup errors
+
+      // Rename staging directory to target (atomic operation)
+      await rename(stagingPath, folderPath);
+
+      console.log(`✅ Cover added successfully: ${resolve(folderPath, 'cover.webp')}`);
+    } catch (swapError) {
+      // If the swap fails, preserve staging directory for manual recovery
+      shouldCleanupStaging = false;
+      console.error(`Failed to complete cover replacement. Staging directory preserved at: ${stagingPath}`);
+      throw new Error(`Failed to complete cover replacement: ${swapError}`);
+    }
+  } catch (error) {
+    // Clean up staging directory only on early failures (before swap attempt)
+    if (shouldCleanupStaging) {
+      try {
+        await rm(stagingPath, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
     }
     throw error;
   }

--- a/scripts/tasks/add-cover.ts
+++ b/scripts/tasks/add-cover.ts
@@ -1,0 +1,134 @@
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+import { mkdir, rm } from 'fs/promises';
+import sharp from 'sharp';
+
+import type { Database } from 'better-sqlite3';
+import type { Folder } from './common/types';
+
+interface AddCoverPayload {
+  imageURL: string;
+  folder: Folder;
+  identifierValue: string;
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const allowedFolders = new Set<Folder>([
+  'covers',
+  'testscovers',
+  'backlogcovers',
+]);
+
+/**
+ * Validates that a folder name is allowed.
+ * @param folder The folder name to validate.
+ */
+function validateFolder(folder: string): asserts folder is Folder {
+  if (!allowedFolders.has(folder as Folder)) {
+    throw new Error(`Invalid folder name: ${folder}`);
+  }
+}
+
+/**
+ * Downloads an image from a URL using native Node.js fetch.
+ */
+async function downloadImage(url: string): Promise<Buffer> {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  } catch (error) {
+    throw new Error(`Failed to download image from ${url}: ${error}`);
+  }
+}
+
+/**
+ * Converts and resizes an image to WebP format using sharp.
+ * 
+ * @param imageBuffer The image buffer to process
+ * @param outputPath The path where the WebP file will be saved
+ */
+async function convertAndResizeImage(
+  imageBuffer: Buffer,
+  outputPath: string
+): Promise<void> {
+  try {
+    await sharp(imageBuffer)
+      .resize(250, 250, { fit: 'inside' })
+      .webp()
+      .toFile(outputPath);
+  } catch (error) {
+    throw new Error(`Failed to convert and resize image: ${error}`);
+  }
+}
+
+/**
+ * Adds a cover image for a game or backlog entry.
+ * 
+ * Process:
+ * 1. Validate the folder parameter
+ * 2. Create/recreate the target folder structure
+ * 3. Download the image from the provided URL
+ * 4. Convert and resize to WebP format (250x250)
+ */
+export async function addCoverToDatabase(
+  _db: Database,
+  payload: AddCoverPayload
+): Promise<void> {
+  const { imageURL, folder, identifierValue } = payload;
+
+  // Validate inputs
+  if (!imageURL || !folder || !identifierValue) {
+    throw new Error('Missing required fields: imageURL, folder, identifierValue');
+  }
+
+  validateFolder(folder);
+
+  // Define paths
+  const publicPath = resolve(__dirname, '..', '..', 'public');
+  const folderPath = resolve(publicPath, folder, identifierValue);
+  const filePath = resolve(folderPath, 'cover.webp');
+
+  try {
+    console.log(`📁 Processing cover for ${folder}/${identifierValue}...`);
+
+    // Delete existing folder if it exists
+    try {
+      console.log(`🗑️  Removing existing folder...`);
+      await rm(folderPath, { recursive: true, force: true });
+    } catch {
+      // Folder doesn't exist, which is fine
+    }
+
+    // Create target folder
+    console.log(`📂 Creating folder...`);
+    await mkdir(folderPath, { recursive: true });
+
+    // Download the image
+    console.log(`⬇️  Downloading image from ${imageURL}...`);
+    const imageBuffer = await downloadImage(imageURL);
+
+    // Convert and resize to WebP
+    console.log(`🔄 Converting and resizing image to WebP (250x250)...`);
+    await convertAndResizeImage(imageBuffer, filePath);
+
+    console.log(`✅ Cover added successfully: ${filePath}`);
+  } catch (error) {
+    // Clean up on error
+    try {
+      await rm(folderPath, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+    throw error;
+  }
+}

--- a/scripts/tasks/common/types.ts
+++ b/scripts/tasks/common/types.ts
@@ -12,7 +12,8 @@ export type TaskType =
   | "UPDATE_TEST"
   | "DELETE_TEST"
   | "UPDATE_TIER_LIST" 
-  | "COPY_COVERS";
+  | "COPY_COVERS" 
+  | "ADD_COVER";
 
 export type Folder = "covers" | "testscovers" | "backlogcovers";
 
@@ -93,4 +94,10 @@ export interface CopyCoversPayload {
   destinationFolder: Folder;
   source_games_textarea: string;
   destination_games_textarea: string;
+}
+
+export interface AddCoverPayload {
+  imageURL: string;
+  folder: Folder;
+  identifierValue: string;
 }

--- a/scripts/tasks/common/utils.ts
+++ b/scripts/tasks/common/utils.ts
@@ -1,4 +1,4 @@
-import type { Platform, GameGenre, IdentifierKind } from "./types";
+import type { Platform, GameGenre, IdentifierKind, Folder } from "./types";
 
 const PLATFORMS_MAP = {
     'PC': 1,
@@ -31,6 +31,12 @@ const GENRES_MAP = {
     'Strategy': 19,
     'Misc': 20
 };
+
+const allowedFolders = new Set<Folder>([
+  'covers',
+  'testscovers',
+  'backlogcovers',
+]);
 
 export function platformToInt(platform: Platform) {
     return PLATFORMS_MAP[platform] || 0;
@@ -76,4 +82,14 @@ export function findIdsInTextArea(textAreaContent?: string) {
     return textAreaContent.split("\n")
         .map(s => s.trim())
         .filter(s => s.length > 0);
+}
+
+/**
+ * Validates that a folder name is allowed.
+ * @param folder The folder name to validate.   
+ */
+export function validateFolder(folder: string): asserts folder is Folder {
+  if (!allowedFolders.has(folder as Folder)) {
+    throw new Error(`Invalid folder name: ${folder}`);
+  }
 }

--- a/scripts/tasks/copy-covers.ts
+++ b/scripts/tasks/copy-covers.ts
@@ -3,9 +3,10 @@ import { findIdsInTextArea } from './common/utils';
 import { fileURLToPath } from 'url';
 import { dirname, resolve, isAbsolute, sep, relative } from 'path';
 import { access, cp } from 'fs/promises';
+import { validateFolder } from "./common/utils";
 
 import type { Database } from 'better-sqlite3';
-import type { CopyCoversPayload, Folder } from './common/types';
+import type { CopyCoversPayload } from './common/types';
 
 export type PairSummary = {
   sourceId: string;
@@ -29,12 +30,6 @@ type ValidatedPairs = {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const allowedFolders = new Set<Folder>([
-  'covers',
-  'testscovers',
-  'backlogcovers',
-]);
-
 function resolveWithin(basePath: string, value: string): string {
   const candidate = resolve(basePath, value);
   const relativePath = relative(basePath, candidate);
@@ -49,16 +44,6 @@ function resolveWithin(basePath: string, value: string): string {
   }
 
   return candidate;
-}
-
-/**
- * Validates that a folder name is allowed.
- * @param folder The folder name to validate.   
- */
-function validateFolder(folder: string): asserts folder is Folder {
-  if (!allowedFolders.has(folder as Folder)) {
-    throw new Error(`Invalid folder name: ${folder}`);
-  }
 }
 
 /**

--- a/scripts/tasks/index.ts
+++ b/scripts/tasks/index.ts
@@ -12,3 +12,4 @@ export * from './update-test';
 export * from './delete-test';
 export * from './update-tier-lists';
 export * from './copy-covers';
+export * from './add-cover';


### PR DESCRIPTION
This script allows adding a cover image for a game or backlog entry by validating the folder, downloading the image, and converting it to WebP format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated cover-image processing.
  * Cover images are validated, downloaded, resized to 250×250 pixels, and converted to WebP format.
  * Supported storage locations are checked before processing.
  * Cover-image processing is now handled through the general automated task system.
* **Bug Fixes**
  * Failed cover-image processing now cleans up incomplete output, helping prevent unusable or partially generated files.
  * Folder validation is shared consistently across cover-related tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->