### PR TITLE
Update locale fetching in request configuration

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,11 +1,12 @@
+import * as rootParams from 'next/root-params';
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from '@/i18n/routing';
 import {hasLocale} from 'next-intl';
 
-export default getRequestConfig(async ({requestLocale}) => {
+export default getRequestConfig(async () => {
   
   // Typically corresponds to the `[locale]` segment
-  const requested = await requestLocale;
+  const requested = await rootParams.locale();;
   const locale = hasLocale(routing.locales, requested)
     ? requested
     : routing.defaultLocale;


### PR DESCRIPTION
Replace requestLocale with rootParams.locale to fetch the locale.
https://next-intl.dev/blog/nextjs-root-params