### PR TITLE
Refactor TierLists tests to use real components

### DIFF
--- a/src/components/tierList/TierListControls.tsx
+++ b/src/components/tierList/TierListControls.tsx
@@ -13,6 +13,7 @@ export function TierListControls({ onToggleSort }: TierListControlsProps) {
     return (
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
             <Button 
+                data-testid="toggle-sort"
                 variant="outlined" 
                 onClick={onToggleSort}
                 startIcon={<SwapVertIcon />}

--- a/src/components/tierList/TierLists.test.tsx
+++ b/src/components/tierList/TierLists.test.tsx
@@ -24,16 +24,6 @@ vi.mock('next-intl', () => ({
     },
 }));
 
-// Keep the controls mocked because the real controls render an icon-only MUI Button
-// (no accessible text) — mocking preserves a test-friendly toggle button with a testid.
-vi.mock('./TierListControls', () => ({
-    TierListControls: ({ onToggleSort }: { onToggleSort: () => void }) => (
-        <button data-testid="toggle-sort" onClick={onToggleSort}>
-            Toggle
-        </button>
-    ),
-}));
-
 // Use the real QueryErrorState, TierListBoard, DistributionBar and DisclaimerAccordion
 // (we removed the mocks for them so the tests exercise more of the real UI).
 


### PR DESCRIPTION
Removed mocks for TierListControls to use real components in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tier list tests to exercise the actual controls implementation while preserving existing API and translation test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->